### PR TITLE
interactive pyqtgraph viewer

### DIFF
--- a/pycine/viewer.py
+++ b/pycine/viewer.py
@@ -1,0 +1,85 @@
+from PyQt5 import QtCore, QtWidgets
+import pyqtgraph as pg
+# backward compatibility default is col-major in pyqtgraph so change
+pg.setConfigOptions(imageAxisOrder="row-major")
+
+
+class Cine_viewer(QtWidgets.QMainWindow):
+    def __init__(self, frame_reader):
+        super(Cine_viewer, self).__init__()
+        self.frame_reader = frame_reader
+
+        self.setWindowTitle("Cine viewer")
+        size = (640, 480)
+        self.resize(*size)
+
+        layout = QtWidgets.QGridLayout()
+
+        image_view = pg.ImageView()
+        self.image_view = image_view
+        layout.addWidget(image_view, 0, 0)
+
+        if frame_reader.full_size == 1:
+            image = self.frame_reader[0]
+            self.image_view.setImage(image)
+        else:
+            frame_slider = QtWidgets.QSlider()
+            frame_slider.setOrientation(QtCore.Qt.Horizontal)
+            frame_slider.setMinimum(1) # maybe change to FirstImageNo in cine file
+            frame_slider.setMaximum(frame_reader.full_size)
+            frame_slider.setTracking(True)  # call update on mouse drag
+            frame_slider.setSingleStep(1)
+            frame_slider.setValue(frame_reader.start_index + 1)
+            self.frame_slider = frame_slider
+            layout.addWidget(frame_slider, 1, 0)
+
+            slider_label_left = QtWidgets.QLabel()
+            slider_label_left.setText("{}".format(frame_slider.minimum()))
+            layout.addWidget(slider_label_left, 2, 0)
+
+            slider_label = QtWidgets.QLabel()
+            slider_label.setAlignment(QtCore.Qt.AlignCenter)
+            self.slider_label = slider_label
+            layout.addWidget(slider_label, 2, 0)
+
+            slider_label_right = QtWidgets.QLabel()
+            slider_label_right.setText("{}".format(self.frame_slider.maximum()))
+            slider_label_right.setAlignment(QtCore.Qt.AlignRight)
+            layout.addWidget(slider_label_right, 2, 0)
+
+            self.update_frame(frame_reader.start_index + 1, autoLevels=True)
+            # do this last to avoid double update with slider setValue
+            frame_slider.valueChanged.connect(self.update_frame)
+
+        widget = QtWidgets.QWidget()
+        widget.setLayout(layout)
+        self.setCentralWidget(widget)
+
+    def set_frame(self, frame_index):
+        # indirectly call update frame
+        self.frame_slider.setValue(frame_index)
+
+    def update_frame(self, frame_index, autoLevels=False):
+        image = self.frame_reader[frame_index - 1]
+        self.image_view.setImage(image, autoLevels=autoLevels)
+        self.slider_label.setText("Frame: {}".format(frame_index))
+
+
+def view_cine(frame_reader):
+    """Start an interactive viewer for a cine file
+
+    Parameters
+    ----------
+    frame_reader : pycine.raw.Frame_reader
+        Object for the cine_file to be viewed
+
+    Returns
+    -------
+    None
+    """
+    app = QtWidgets.QApplication([])
+    window = Cine_viewer(frame_reader)
+    window.show()
+
+    # Start the event loop.
+    app.exec_()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="This package allows handling of .cine files created by Vision Research Phantom® cameras.",
     entry_points={"console_scripts": ["pfs_meta = pycine.cli.pfs_meta:cli", "pfs_raw = pycine.cli.pfs_raw:cli"]},
     include_package_data=True,
-    install_requires=["click", "docopt", "opencv-python", "colorama", "timecode"],
+    install_requires=["click", "docopt", "opencv-python", "colorama", "timecode", "pyqt5", "pyqtgraph"],
     long_description=long_description,
     long_description_content_type="text/markdown",
     name="pycine",


### PR DESCRIPTION
Following changes are suggested:
- New module `viewer.py` to house the new viewer code.
- Remake of frame_reader from a `yield` iterator to a class `Frame_reader` that itself is an iterator. Then in addition one can get images using `__getitem__` or `[]` syntax.
- Some remake in `cli/pfs_raw.py` to instead of showing image with OpenCV use the new viewer.

Uncertainties:
- Should the viewer have frame index values similar to PCC (i.e. use the `FirstFrameNo` attribute in header)?
- Should the `Frame_reader` class have a possibility to follow `FirstFrameNo` as above?
- Is the installation working with the added dependencies of `pyqt` and `pyqtgraph`? (I did not get it to work in venv)

The code has not the type suggestions that has been added to the rest of the code base but that can be fixed when the code looks good. Otherwise, I am open for suggestions.